### PR TITLE
Fix BUG-001: GetByIdAsync now filters by IsActive

### DIFF
--- a/Backend/ECommerce.API/Properties/launchSettings.json
+++ b/Backend/ECommerce.API/Properties/launchSettings.json
@@ -1,23 +1,22 @@
-﻿{
-  "$schema": "https://json.schemastore.org/launchsettings.json",
+{
   "profiles": {
     "http": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "http://localhost:5272",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:5272"
     },
     "https": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "https://localhost:7252;http://localhost:5272",
+      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:7252;http://localhost:5272"
     }
-  }
+  },
+  "$schema": "https://json.schemastore.org/launchsettings.json"
 }

--- a/Backend/ECommerce.API/Properties/launchSettings.json
+++ b/Backend/ECommerce.API/Properties/launchSettings.json
@@ -1,22 +1,25 @@
 {
+  "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
     "http": {
       "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5272",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:5272"
+      }
     },
     "https": {
       "commandName": "Project",
+      "dotnetRunMessages": true,
       "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7252;http://localhost:5272",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "dotnetRunMessages": true,
-      "applicationUrl": "https://localhost:7252;http://localhost:5272"
+      }
     }
-  },
-  "$schema": "https://json.schemastore.org/launchsettings.json"
+  }
 }

--- a/Backend/ECommerce.Infrastructure/Repositories/GenericRepository.cs
+++ b/Backend/ECommerce.Infrastructure/Repositories/GenericRepository.cs
@@ -17,7 +17,11 @@ public class GenericRepository<T> : IGenericRepository<T> where T : BaseEntity
         _dbSet = context.Set<T>();
     }
 
-    public async Task<T?> GetByIdAsync(int id) => await _dbSet.FindAsync(id);
+    public async Task<T?> GetByIdAsync(int id)
+    {
+        return await _dbSet.FirstOrDefaultAsync(e => e.Id == id && e.IsActive);
+    }
+
 
     public async Task<IReadOnlyList<T>> GetAllAsync() =>
         await _dbSet.Where(e => e.IsActive).ToListAsync();


### PR DESCRIPTION
## Summary
- Changed `FindAsync` to `FirstOrDefaultAsync` with `IsActive` check
- Soft-deleted entities are no longer accessible by ID
- Updated launchSettings to auto-open browser with Swagger

## Fixes
Closes #1

## Test Plan
- [ ] Get product by ID → returns product
- [ ] Soft-delete a product → Get by ID returns not found
- [ ] Swagger opens automatically on project run