### PR TITLE
feat(ECOM-018): Admin Access System

### DIFF
--- a/Backend/ECommerce.API/Controllers/AdminController.cs
+++ b/Backend/ECommerce.API/Controllers/AdminController.cs
@@ -1,0 +1,33 @@
+using System.Security.Claims;
+using ECommerce.Application.DTOs;
+using ECommerce.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ECommerce.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize(Roles = "Admin")]
+public class AdminController : ControllerBase
+{
+    private readonly IAuthService _authService;
+
+    public AdminController(IAuthService authService)
+    {
+        _authService = authService;
+    }
+
+    private int GetUserId() => int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+
+    [HttpGet("users")]
+    public async Task<IActionResult> GetAllUsers() =>
+        Ok(await _authService.GetAllUsersAsync());
+
+    [HttpPut("users/{id}/role")]
+    public async Task<IActionResult> UpdateUserRole(int id, [FromBody] UpdateUserRoleDto dto)
+    {
+        var result = await _authService.UpdateUserRoleAsync(id, dto, GetUserId());
+        return result.Success ? Ok(result) : BadRequest(result);
+    }
+}

--- a/Backend/ECommerce.API/Controllers/AuthController.cs
+++ b/Backend/ECommerce.API/Controllers/AuthController.cs
@@ -1,5 +1,6 @@
 using ECommerce.Application.DTOs.Auth;
 using ECommerce.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace ECommerce.API.Controllers;
@@ -19,6 +20,15 @@ public class AuthController : ControllerBase
     public async Task<IActionResult> Register([FromBody] RegisterDto dto)
     {
         var result = await _authService.RegisterAsync(dto);
+        if (!result.Success) return BadRequest(result);
+        return Ok(result);
+    }
+
+    [Authorize(Roles = "Admin")]
+    [HttpPost("register-admin")]
+    public async Task<IActionResult> RegisterAdmin([FromBody] RegisterDto dto)
+    {
+        var result = await _authService.RegisterAdminAsync(dto);
         if (!result.Success) return BadRequest(result);
         return Ok(result);
     }

--- a/Backend/ECommerce.Application/DTOs/RoleManagementDto.cs
+++ b/Backend/ECommerce.Application/DTOs/RoleManagementDto.cs
@@ -1,0 +1,18 @@
+namespace ECommerce.Application.DTOs;
+
+public class UpdateUserRoleDto
+{
+    public int RoleId { get; set; }
+}
+
+public class UserWithRoleDto
+{
+    public int Id { get; set; }
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string Phone { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
+    public bool IsActive { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/Backend/ECommerce.Application/Interfaces/IAuthService.cs
+++ b/Backend/ECommerce.Application/Interfaces/IAuthService.cs
@@ -6,5 +6,8 @@ namespace ECommerce.Application.Interfaces;
 public interface IAuthService
 {
     Task<ApiResponse<AuthResponseDto>> RegisterAsync(RegisterDto dto);
+    Task<ApiResponse<AuthResponseDto>> RegisterAdminAsync(RegisterDto dto);
     Task<ApiResponse<AuthResponseDto>> LoginAsync(LoginDto dto);
+    Task<ApiResponse<List<UserWithRoleDto>>> GetAllUsersAsync();
+    Task<ApiResponse<bool>> UpdateUserRoleAsync(int userId, UpdateUserRoleDto dto, int currentUserId);
 }

--- a/Backend/ECommerce.Application/Services/AuthService.cs
+++ b/Backend/ECommerce.Application/Services/AuthService.cs
@@ -52,6 +52,33 @@ public class AuthService : IAuthService
         }, "Registration successful");
     }
 
+    public async Task<ApiResponse<AuthResponseDto>> RegisterAdminAsync(RegisterDto dto)
+    {
+        if (await _userRepo.EmailExistsAsync(dto.Email))
+            return ApiResponse<AuthResponseDto>.ErrorResponse("Email already exists");
+
+        var user = new User
+        {
+            FirstName = dto.FirstName,
+            LastName = dto.LastName,
+            Email = dto.Email,
+            Phone = dto.Phone,
+            PasswordHash = HashPassword(dto.Password),
+            RoleId = 1 // Admin
+        };
+
+        await _userRepo.AddAsync(user);
+        var dbUser = await _userRepo.GetByEmailAsync(user.Email);
+
+        return ApiResponse<AuthResponseDto>.SuccessResponse(new AuthResponseDto
+        {
+            Token = GenerateJwtToken(dbUser!),
+            Email = dbUser!.Email,
+            FullName = $"{dbUser.FirstName} {dbUser.LastName}",
+            Role = dbUser.Role.Name
+        }, "Admin registration successful");
+    }
+
     public async Task<ApiResponse<AuthResponseDto>> LoginAsync(LoginDto dto)
     {
         var user = await _userRepo.GetByEmailAsync(dto.Email);
@@ -65,6 +92,41 @@ public class AuthService : IAuthService
             FullName = $"{user.FirstName} {user.LastName}",
             Role = user.Role.Name
         }, "Login successful");
+    }
+
+    public async Task<ApiResponse<List<UserWithRoleDto>>> GetAllUsersAsync()
+    {
+        var users = await _userRepo.GetAllUsersWithRolesAsync();
+        var dtos = users.Select(u => new UserWithRoleDto
+        {
+            Id = u.Id,
+            FirstName = u.FirstName,
+            LastName = u.LastName,
+            Email = u.Email,
+            Phone = u.Phone,
+            Role = u.Role?.Name ?? "",
+            IsActive = u.IsActive,
+            CreatedAt = u.CreatedAt
+        }).ToList();
+        return ApiResponse<List<UserWithRoleDto>>.SuccessResponse(dtos);
+    }
+
+    public async Task<ApiResponse<bool>> UpdateUserRoleAsync(int userId, UpdateUserRoleDto dto, int currentUserId)
+    {
+        if (userId == currentUserId)
+            return ApiResponse<bool>.ErrorResponse("Cannot change your own role");
+
+        var user = await _userRepo.GetByIdAsync(userId);
+        if (user == null)
+            return ApiResponse<bool>.ErrorResponse("User not found");
+
+        var role = await _roleRepo.GetByIdAsync(dto.RoleId);
+        if (role == null)
+            return ApiResponse<bool>.ErrorResponse("Invalid role");
+
+        user.RoleId = dto.RoleId;
+        await _userRepo.UpdateAsync(user);
+        return ApiResponse<bool>.SuccessResponse(true, "User role updated successfully");
     }
 
     private string GenerateJwtToken(User user)

--- a/Backend/ECommerce.Core/Interfaces/IUserRepository.cs
+++ b/Backend/ECommerce.Core/Interfaces/IUserRepository.cs
@@ -6,4 +6,5 @@ public interface IUserRepository : IGenericRepository<User>
 {
     Task<User?> GetByEmailAsync(string email);
     Task<bool> EmailExistsAsync(string email);
+    Task<IReadOnlyList<User>> GetAllUsersWithRolesAsync();
 }

--- a/Backend/ECommerce.Infrastructure/Data/AppDbContext.cs
+++ b/Backend/ECommerce.Infrastructure/Data/AppDbContext.cs
@@ -110,6 +110,19 @@ public class AppDbContext : DbContext
             new Role { Id = 1, Name = "Admin", CreatedAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
             new Role { Id = 2, Name = "Customer", CreatedAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc) }
         );
+
+        // Seed Admin User (password: Admin@123)
+        modelBuilder.Entity<User>().HasData(new User
+        {
+            Id = 1,
+            FirstName = "Admin",
+            LastName = "User",
+            Email = "admin@ecommerce.com",
+            PasswordHash = "tZOBeHHxo1QXurQLCcV8+Kj6tYs8pXMWYxu9fUhPighe/Co2eAt/2SjGleZIrX7ofD7gjJsEnslCgtXbzHmYlQGJgS2sQ1d3eIZKbLQBEtaBN8+JvaPb9XCY3XccttJMIsu2CNR0AMjrIIXJ6YULzpopPOXMcRyq3OmOE/ZgjTA=.wP2mVCjA9rLVSquBDmUAVv3ngUO5DiQtpkGtHi0CuVUi+2z6cyt3Jli+gDBA8pGpW7Tf5ms8awrPB42kHley3Q==",
+            Phone = "0000000000",
+            RoleId = 1,
+            CreatedAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        });
     }
 
     public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)

--- a/Backend/ECommerce.Infrastructure/Migrations/20260313060525_SeedAdminUser.Designer.cs
+++ b/Backend/ECommerce.Infrastructure/Migrations/20260313060525_SeedAdminUser.Designer.cs
@@ -4,6 +4,7 @@ using ECommerce.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ECommerce.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260313060525_SeedAdminUser")]
+    partial class SeedAdminUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/ECommerce.Infrastructure/Migrations/20260313060525_SeedAdminUser.cs
+++ b/Backend/ECommerce.Infrastructure/Migrations/20260313060525_SeedAdminUser.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ECommerce.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedAdminUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "Users",
+                columns: new[] { "Id", "CreatedAt", "Email", "FirstName", "IsActive", "LastName", "PasswordHash", "Phone", "RoleId", "UpdatedAt" },
+                values: new object[] { 1, new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), "admin@ecommerce.com", "Admin", true, "User", "tZOBeHHxo1QXurQLCcV8+Kj6tYs8pXMWYxu9fUhPighe/Co2eAt/2SjGleZIrX7ofD7gjJsEnslCgtXbzHmYlQGJgS2sQ1d3eIZKbLQBEtaBN8+JvaPb9XCY3XccttJMIsu2CNR0AMjrIIXJ6YULzpopPOXMcRyq3OmOE/ZgjTA=.wP2mVCjA9rLVSquBDmUAVv3ngUO5DiQtpkGtHi0CuVUi+2z6cyt3Jli+gDBA8pGpW7Tf5ms8awrPB42kHley3Q==", "0000000000", 1, null });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Users",
+                keyColumn: "Id",
+                keyValue: 1);
+        }
+    }
+}

--- a/Backend/ECommerce.Infrastructure/Repositories/UserRepository.cs
+++ b/Backend/ECommerce.Infrastructure/Repositories/UserRepository.cs
@@ -16,4 +16,7 @@ public class UserRepository : GenericRepository<User>, IUserRepository
     public async Task<bool> EmailExistsAsync(string email) =>
     await _context.Users.AnyAsync(u => u.Email == email && u.IsActive);
 
+    public async Task<IReadOnlyList<User>> GetAllUsersWithRolesAsync() =>
+        await _dbSet.Include(u => u.Role).ToListAsync();
+
 }


### PR DESCRIPTION
## Summary
- Seed default admin user (`admin@ecommerce.com` / `Admin@123`) via migration
- Add `POST api/auth/register-admin` endpoint (Admin-only) to create new admins
- Add `GET api/admin/users` to list all users with roles
- Add `PUT api/admin/users/{id}/role` to promote/demote users (prevents self-demotion)

## Why
Team members (Mayuri, Shivani, Rohan) cannot test Admin-protected endpoints (Product CRUD, Order status, Category CRUD) because registration hardcodes RoleId=2 (Customer). This unblocks the entire team.

## Test plan
- [ ] Run `dotnet ef database update` → admin user seeded
- [ ] `POST api/auth/login` with `admin@ecommerce.com` / `Admin@123` → get admin JWT token
- [ ] Use admin token → test all `[Authorize(Roles="Admin")]` endpoints
- [ ] `POST api/auth/register-admin` → create new admin
- [ ] `GET api/admin/users` → list all users
- [ ] `PUT api/admin/users/{id}/role` → change user role
- [ ] Verify admin cannot demote themselves