### PR TITLE
fix(BUG-005,006,007): cart stock, order status validation, admin orders endpoint

### DIFF
--- a/Backend/ECommerce.API/Controllers/OrdersController.cs
+++ b/Backend/ECommerce.API/Controllers/OrdersController.cs
@@ -32,6 +32,11 @@ public class OrdersController : ControllerBase
     public async Task<IActionResult> GetMyOrders() =>
         Ok(await _orderService.GetUserOrdersAsync(GetUserId()));
 
+    [HttpGet("all")]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> GetAllOrders() =>
+        Ok(await _orderService.GetAllOrdersAsync());
+
     [HttpGet("{id}")]
     public async Task<IActionResult> GetOrder(int id)
     {

--- a/Backend/ECommerce.API/Properties/launchSettings.json
+++ b/Backend/ECommerce.API/Properties/launchSettings.json
@@ -16,7 +16,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7252;http://localhost:5272",
+      "applicationUrl": "https://localhost:7252;http://localhost:7001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Backend/ECommerce.Application/Interfaces/IOrderService.cs
+++ b/Backend/ECommerce.Application/Interfaces/IOrderService.cs
@@ -6,6 +6,7 @@ namespace ECommerce.Application.Interfaces;
 public interface IOrderService
 {
     Task<ApiResponse<OrderDto>> CreateOrderAsync(int userId, CreateOrderDto dto);
+    Task<ApiResponse<List<OrderDto>>> GetAllOrdersAsync();
     Task<ApiResponse<List<OrderDto>>> GetUserOrdersAsync(int userId);
     Task<ApiResponse<OrderDto>> GetOrderByIdAsync(int orderId);
     Task<ApiResponse<OrderDto>> UpdateOrderStatusAsync(int orderId, OrderStatus status);

--- a/Backend/ECommerce.Application/Services/CartService.cs
+++ b/Backend/ECommerce.Application/Services/CartService.cs
@@ -28,11 +28,12 @@ public class CartService : ICartService
         if (product == null)
             return ApiResponse<CartDto>.ErrorResponse("Product not found");
 
-        if (product.StockQuantity < dto.Quantity)
-            return ApiResponse<CartDto>.ErrorResponse("Insufficient stock");
-
         var cart = await GetOrCreateCartAsync(userId);
         var existingItem = cart.CartItems.FirstOrDefault(ci => ci.ProductId == dto.ProductId);
+
+        var totalQty = (existingItem?.Quantity ?? 0) + dto.Quantity;
+        if (product.StockQuantity < totalQty)
+            return ApiResponse<CartDto>.ErrorResponse($"Insufficient stock. Available: {product.StockQuantity}, In cart: {existingItem?.Quantity ?? 0}");
 
         if (existingItem != null)
         {

--- a/Backend/ECommerce.Application/Services/OrderService.cs
+++ b/Backend/ECommerce.Application/Services/OrderService.cs
@@ -82,6 +82,12 @@ foreach (var item in cart.CartItems)
         return ApiResponse<OrderDto>.SuccessResponse(MapToDto(order), "Order placed successfully");
     }
 
+    public async Task<ApiResponse<List<OrderDto>>> GetAllOrdersAsync()
+    {
+        var orders = await _orderRepo.GetAllOrdersAsync();
+        return ApiResponse<List<OrderDto>>.SuccessResponse(orders.Select(MapToDto).ToList());
+    }
+
     public async Task<ApiResponse<List<OrderDto>>> GetUserOrdersAsync(int userId)
     {
         var orders = await _orderRepo.GetOrdersByUserIdAsync(userId);
@@ -96,11 +102,25 @@ foreach (var item in cart.CartItems)
         return ApiResponse<OrderDto>.SuccessResponse(MapToDto(order));
     }
 
+    private static readonly Dictionary<OrderStatus, OrderStatus[]> _validTransitions = new()
+    {
+        { OrderStatus.Pending, new[] { OrderStatus.Confirmed, OrderStatus.Cancelled } },
+        { OrderStatus.Confirmed, new[] { OrderStatus.Processing, OrderStatus.Cancelled } },
+        { OrderStatus.Processing, new[] { OrderStatus.Shipped, OrderStatus.Cancelled } },
+        { OrderStatus.Shipped, new[] { OrderStatus.Delivered } },
+        { OrderStatus.Delivered, new[] { OrderStatus.Returned } },
+    };
+
     public async Task<ApiResponse<OrderDto>> UpdateOrderStatusAsync(int orderId, OrderStatus status)
     {
         var order = await _orderRepo.GetOrderWithDetailsAsync(orderId);
         if (order == null)
             return ApiResponse<OrderDto>.ErrorResponse("Order not found");
+
+        if (!_validTransitions.ContainsKey(order.Status) ||
+            !_validTransitions[order.Status].Contains(status))
+            return ApiResponse<OrderDto>.ErrorResponse(
+                $"Invalid status transition from {order.Status} to {status}");
 
         order.Status = status;
         await _orderRepo.UpdateAsync(order);

--- a/Backend/ECommerce.Core/Interfaces/IOrderRepository.cs
+++ b/Backend/ECommerce.Core/Interfaces/IOrderRepository.cs
@@ -4,6 +4,7 @@ namespace ECommerce.Core.Interfaces;
 
 public interface IOrderRepository : IGenericRepository<Order>
 {
+    Task<IReadOnlyList<Order>> GetAllOrdersAsync();
     Task<IReadOnlyList<Order>> GetOrdersByUserIdAsync(int userId);
     Task<Order?> GetOrderWithDetailsAsync(int orderId);
     Task<Order?> GetOrderByOrderNumberAsync(string orderNumber);

--- a/Backend/ECommerce.Infrastructure/Repositories/OrderRepository.cs
+++ b/Backend/ECommerce.Infrastructure/Repositories/OrderRepository.cs
@@ -9,6 +9,14 @@ public class OrderRepository : GenericRepository<Order>, IOrderRepository
 {
     public OrderRepository(AppDbContext context) : base(context) { }
 
+    public async Task<IReadOnlyList<Order>> GetAllOrdersAsync() =>
+        await _dbSet.Where(o => o.IsActive)
+            .Include(o => o.OrderItems).ThenInclude(oi => oi.Product)
+            .Include(o => o.ShippingAddress)
+            .Include(o => o.Payment)
+            .OrderByDescending(o => o.CreatedAt)
+            .ToListAsync();
+
     public async Task<IReadOnlyList<Order>> GetOrdersByUserIdAsync(int userId) =>
         await _dbSet.Where(o => o.UserId == userId && o.IsActive)
             .Include(o => o.OrderItems).ThenInclude(oi => oi.Product)


### PR DESCRIPTION
## Summary
- **BUG-005**: Cart stock check now includes existing cart quantity (e.g., stock=5, cart has 3, adding 4 more is rejected)
- **BUG-006**: Order status transitions validated with allowed transition map (Pending→Confirmed→Processing→Shipped→Delivered, with cancel/return rules)
- **BUG-007**: Added `GET /api/orders/all` admin-only endpoint to fetch all customer orders

## Test plan
- [ ] Add items to cart multiple times and verify stock check accounts for existing quantity
- [ ] Try invalid status transitions (e.g., Delivered→Pending) and verify error response
- [ ] Try valid status transitions (e.g., Pending→Confirmed) and verify success
- [ ] Call GET /api/orders/all as Admin and verify all orders returned
- [ ] Call GET /api/orders/all as Customer and verify 403 Forbidden

Closes #5, Closes #6, Closes #7