### PR TITLE
fix: pin EF Core packages to 9.0.15 to resolve NU1605

### DIFF
--- a/Backend/ECommerce.API/ECommerce.API.csproj
+++ b/Backend/ECommerce.API/ECommerce.API.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.*" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.14" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.*">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.15">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Backend/ECommerce.Application/ECommerce.Application.csproj
+++ b/Backend/ECommerce.Application/ECommerce.Application.csproj
@@ -5,9 +5,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.14" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.14" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.14">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.15">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Backend/ECommerce.Infrastructure/ECommerce.Infrastructure.csproj
+++ b/Backend/ECommerce.Infrastructure/ECommerce.Infrastructure.csproj
@@ -6,9 +6,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.14" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.*">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.15">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

- **Problem:** Infrastructure and API csproj files pinned `Microsoft.EntityFrameworkCore` to `9.0.14` but used `9.0.*` for SqlServer/Tools/Design packages. After 9.0.15 released, the wildcard resolved to 9.0.15 and transitively required EF Core 9.0.15 — triggering NU1605 "package downgrade detected" build errors.
- **Fix:** Pin all EF Core packages (Core, SqlServer, Tools, Design) to `9.0.15` across all three projects (API, Application, Infrastructure) for consistent restore + build.

## Test plan

- [x] `dotnet build ECommerce.sln` — completes with 0 errors (previously failed with 2 NU1605 errors)
- [ ] Reviewer verifies local build works after pulling
- [ ] Reviewer confirms no EF runtime regressions