### PR TITLE
fix: enable Swagger in all environments + root redirect

### DIFF
--- a/Backend/ECommerce.API/Program.cs
+++ b/Backend/ECommerce.API/Program.cs
@@ -1,10 +1,8 @@
 using System.Text;
 using ECommerce.Infrastructure;
 using ECommerce.Infrastructure.Data;
-using ECommerce.Application.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
-using ECommerce.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -74,11 +72,11 @@ using (var scope = app.Services.CreateScope())
     await DbInitializer.SeedAdminAsync(context);
 }
 
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+app.UseSwagger();
+app.UseSwaggerUI();
+
+app.MapGet("/", () => Results.Redirect("/swagger"))
+    .ExcludeFromDescription();
 
 app.UseHttpsRedirection();
 app.UseCors("AllowAngular");


### PR DESCRIPTION
## Summary

- **Problem:** Mayuri and Shivani reported that after pulling latest, the API runs but no endpoints are visible in Swagger. Root cause: `app.UseSwagger()` was gated behind `if (app.Environment.IsDevelopment())`. If they run the API without the Development env var (different launch profile, dotnet CLI variant, container, etc.), Swagger UI never registers.
- **Fix:** Enable Swagger middleware unconditionally. For internal dev API this is the right default — every teammate sees the docs without env-var ceremony.
- **Bonus:** Add a root URL (`/`) -> `/swagger` redirect so visiting the base URL lands on the docs instead of 404.
- **Cleanup:** Remove duplicate `using ECommerce.Infrastructure;` and unused `using ECommerce.Application.Services;` from Program.cs.

## Test plan

- [x] `dotnet build` — 0 errors
- [ ] Run API, visit `https://localhost:7252/` → should redirect to `/swagger`
- [ ] Mayuri & Shivani pull latest and confirm endpoints are visible